### PR TITLE
fix: Remove Discovery API key URL from Discovery URL

### DIFF
--- a/docs/quickstart/index.html
+++ b/docs/quickstart/index.html
@@ -35,8 +35,7 @@ limitations under the License.
       var API_KEY = '<YOUR_API_KEY>';
 
       // Array of API discovery doc URLs for APIs used by the quickstart
-      var DISCOVERY_DOCS = [
-        'https://docs.googleapis.com/$discovery/rest?version=v1&key=<YOUR_API_KEY>'];
+      var DISCOVERY_DOCS = ['https://docs.googleapis.com/$discovery/rest?version=v1'];
 
       // Authorization scopes required by the API; multiple scopes can be
       // included, separated by spaces.


### PR DESCRIPTION
Removes the API key query param from the Docs API Discovery URL.
It is not needed after the API was made public.